### PR TITLE
79 add role support to connection and query

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ client = RubySnowflake::Client.new(
   "snowflake-user",                                     # Your snowflake user
   "some_warehouse",                                     # The name of your warehouse to use by default
   "some_database",                                      # The name of the database in the context of which the queries will run
+  default_role: "some_role",                            # The name of the role with which the queries will run. A `nil` value uses the primary role of the user.
   max_connections: 12,                                  # Config options can be passed in
   connection_timeout: 45,                               # See below for the full set of options
   query_timeout: 1200,                                  # how long to wait for queries, in seconds
@@ -52,6 +53,7 @@ Available ENV variables (see below in the config section for details)
 - `SNOWFLAKE_USER`
 - `SNOWFLAKE_DEFAULT_WAREHOUSE`
 - `SNOWFLAKE_DEFAULT_DATABASE`
+- `SNOWFLAKE_DEFAULT_ROLE`
 - `SNOWFLAKE_JWT_TOKEN_TTL`
 - `SNOWFLAKE_CONNECTION_TIMEOUT`
 - `SNOWFLAKE_MAX_CONNECTIONS`
@@ -109,6 +111,14 @@ client.query("SELECT * FROM BIGTABLE", warehouse: "FAST_WH")
 
 ```ruby
 client.query("SELECT * FROM BIGTABLE", schema: "MY_SCHEMA")
+```
+
+## Specifying role
+
+Queries by default use the primary role assigned to the account. If there are multiple roles you can switch between them on a per query basis.
+
+```ruby
+client.query("SELECT * FROM BIGTABLE", role: "MY_ROLE")
 ```
 
 ## Binding parameters

--- a/lib/ruby_snowflake/client.rb
+++ b/lib/ruby_snowflake/client.rb
@@ -74,7 +74,7 @@ module RubySnowflake
     POLLING_INTERVAL = 2 # seconds
 
     # can't be set after initialization
-    attr_reader :connection_timeout, :max_connections, :logger, :max_threads_per_query, :thread_scale_factor, :http_retries, :query_timeout
+    attr_reader :connection_timeout, :max_connections, :logger, :max_threads_per_query, :thread_scale_factor, :http_retries, :query_timeout, :default_role
 
     def self.from_env(logger: DEFAULT_LOGGER,
                       log_level: DEFAULT_LOG_LEVEL,
@@ -102,6 +102,7 @@ module RubySnowflake
         ENV.fetch("SNOWFLAKE_USER"),
         ENV["SNOWFLAKE_DEFAULT_WAREHOUSE"],
         ENV["SNOWFLAKE_DEFAULT_DATABASE"],
+        default_role: ENV.fetch("SNOWFLAKE_DEFAULT_ROLE", nil),
         logger: logger,
         log_level: log_level,
         jwt_token_ttl: jwt_token_ttl,
@@ -116,6 +117,7 @@ module RubySnowflake
 
     def initialize(
       uri, private_key, organization, account, user, default_warehouse, default_database,
+      default_role: nil,
       logger: DEFAULT_LOGGER,
       log_level: DEFAULT_LOG_LEVEL,
       jwt_token_ttl: DEFAULT_JWT_TOKEN_TTL,
@@ -131,6 +133,7 @@ module RubySnowflake
         KeyPairJwtAuthManager.new(organization, account, user, private_key, jwt_token_ttl)
       @default_warehouse = default_warehouse
       @default_database = default_database
+      @default_role = default_role
 
       # set defaults for config settings
       @logger = logger
@@ -147,9 +150,10 @@ module RubySnowflake
       @_enable_polling_queries = false
     end
 
-    def query(query, warehouse: nil, streaming: false, database: nil, schema: nil, bindings: nil)
+    def query(query, warehouse: nil, streaming: false, database: nil, schema: nil, bindings: nil, role: nil)
       warehouse ||= @default_warehouse
       database ||= @default_database
+      role ||= @default_role
 
       query_start_time = Time.now.to_i
       response = nil
@@ -159,7 +163,8 @@ module RubySnowflake
           "schema" => schema&.upcase,
           "database" =>  database&.upcase,
           "statement" => query,
-          "bindings" => bindings
+          "bindings" => bindings,
+          "role" => role
         }
 
         response = request_with_auth_and_headers(

--- a/spec/ruby_snowflake/client_spec.rb
+++ b/spec/ruby_snowflake/client_spec.rb
@@ -438,6 +438,7 @@ RSpec.describe RubySnowflake::Client do
     it_behaves_like "a configuration setting", :thread_scale_factor, 5
     it_behaves_like "a configuration setting", :http_retries, 2
     it_behaves_like "a configuration setting", :query_timeout, 2000
+    it_behaves_like "a configuration setting", :default_role, "OTHER_ROLE"
 
 
     context "with optional settings set through env variables" do
@@ -449,6 +450,7 @@ RSpec.describe RubySnowflake::Client do
         ENV["SNOWFLAKE_THREAD_SCALE_FACTOR"] = "3"
         ENV["SNOWFLAKE_HTTP_RETRIES"] = "33"
         ENV["SNOWFLAKE_QUERY_TIMEOUT"] = "3333"
+        ENV["SNOWFLAKE_DEFAULT_ROLE"] = "OTHER_ROLE"
       end
 
       after do
@@ -459,6 +461,7 @@ RSpec.describe RubySnowflake::Client do
         ENV["SNOWFLAKE_THREAD_SCALE_FACTOR"] = nil
         ENV["SNOWFLAKE_HTTP_RETRIES"] = nil
         ENV["SNOWFLAKE_QUERY_TIMEOUT"] = nil
+        ENV["SNOWFLAKE_DEFAULT_ROLE"] = nil
       end
 
       it "sets the settings" do
@@ -470,6 +473,7 @@ RSpec.describe RubySnowflake::Client do
         expect(client.thread_scale_factor).to eq 3
         expect(client.http_retries).to eq 33
         expect(client.query_timeout).to eq 3333
+        expect(client.default_role).to eq "OTHER_ROLE"
       end
     end
 
@@ -483,6 +487,7 @@ RSpec.describe RubySnowflake::Client do
         expect(client.max_threads_per_query).to eq RubySnowflake::Client::DEFAULT_MAX_THREADS_PER_QUERY
         expect(client.thread_scale_factor).to eq RubySnowflake::Client::DEFAULT_THREAD_SCALE_FACTOR
         expect(client.http_retries).to eq RubySnowflake::Client::DEFAULT_HTTP_RETRIES
+        expect(client.default_role).to be_nil
       end
     end
   end


### PR DESCRIPTION
Adds role configuration to connection and query. A role of `nil` will use the default role configured on the user.

Clone of 
https://github.com/rinsed-org/rb-snowflake-client/pull/81