### PR TITLE
expire token earlier

### DIFF
--- a/lib/ruby_snowflake/client/key_pair_jwt_auth_manager.rb
+++ b/lib/ruby_snowflake/client/key_pair_jwt_auth_manager.rb
@@ -42,7 +42,7 @@ module RubySnowflake
 
       private
         def jwt_token_expired?
-          Time.now.to_i > @token_expires_at
+          Time.now.to_i >= (@token_expires_at - 2)
         end
 
         def public_key_fingerprint


### PR DESCRIPTION
Expires JWT earlier in the client so that doesn't send requests that could expire in network time.