### PR TITLE
add query parameters support

### DIFF
--- a/lib/ruby_snowflake/client.rb
+++ b/lib/ruby_snowflake/client.rb
@@ -140,10 +140,11 @@ module RubySnowflake
       @_enable_polling_queries = false
     end
 
-    def query(query, warehouse: nil, streaming: false, database: nil, schema: nil, bindings: nil, role: nil)
+    def query(query, warehouse: nil, streaming: false, database: nil, schema: nil, bindings: nil, role: nil, parameters: nil)
       warehouse ||= @default_warehouse
       database ||= @default_database
       role ||= @default_role
+      parameters ||= {}
 
       query_start_time = Time.now.to_i
       response = nil
@@ -154,7 +155,8 @@ module RubySnowflake
           "database" =>  database&.upcase,
           "statement" => query,
           "bindings" => bindings,
-          "role" => role
+          "role" => role,
+          "parameters" => parameters
         }
 
         response = request_with_auth_and_headers(


### PR DESCRIPTION
Adds support for https://docs.snowflake.com/en/developer-guide/sql-api/reference#label-sql-api-reference-statements-parameters so that we can pass `query_tag`.

```rb
query("SELECT * FROM FOO", parameters: { query_tag: "tag-bar" } )
```
